### PR TITLE
Fix and enhance BlowePaginationListView functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.4
+
+- Added the ability to pass dynamic parameters for the `onRefresh` and `Retry` actions in `BlowePaginationListView`.
+- Fixed issue with the last item in the list being inside a column, causing visual inconsistencies.
+- Ensured the list is always scrollable, even when the items do not fill the screen, to allow for `onRefresh` functionality.
+
 ## 0.1.3
 
 - Update `README.md` version

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.3.4 <4.0.0"
 
 dependencies:
-  blowe_bloc: ^0.1.0
+  blowe_bloc: ^0.1.3
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blowe_bloc
 description: "An advanced Flutter package for state management and business logic components, extending flutter_bloc."
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/santiagogonzalezblowe/blowe_bloc
 issue_tracker: https://github.com/santiagogonzalezblowe/blowe_bloc/issues
 homepage: https://www.linkedin.com/in/santiagogonzalezblowe/


### PR DESCRIPTION
- Added the ability to pass dynamic parameters for the `onRefresh` and `Retry` actions in `BlowePaginationListView`.
- Fixed the issue where the last item in the list was inside a column, causing visual inconsistencies.
- Ensured the list is always scrollable, even when the items do not fill the screen, to allow for `onRefresh` functionality.
- Updated the version to 0.1.4 in pubspec.yaml.
- Documented changes in CHANGELOG.md.