### PR TITLE
Filter & Empty Widgets in BlowePaginationListView v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.1.5
+
+- Added the ability to pass a custom filter function to dynamically filter items in BlowePaginationListView.
+- Updated the constructor to accept an optional filter parameter.
+- Applied the filter to the items before displaying them.
+- Ensured that the filtering works seamlessly with the existing onRefresh functionality.
+- Made BlowePaginationModel non-abstract to allow instantiation.
+- Added the ability to pass an `emptyWidget` to display when the list is empty.
+- Wrapped the `emptyWidget` in a `RefreshIndicator` to allow onRefresh functionality even when the list is empty.
+- Updated documentation and examples to reflect these changes.
+
 ## 0.1.4
 
 - Added the ability to pass dynamic parameters for the `onRefresh` and `Retry` actions in `BlowePaginationListView`.

--- a/lib/src/model/blowe_pagination_model.dart
+++ b/lib/src/model/blowe_pagination_model.dart
@@ -1,6 +1,6 @@
-/// Abstract class representing a pagination model.
+/// Class representing a pagination model.
 /// This class is used to handle paginated data.
-abstract class BlowePaginationModel<T> {
+class BlowePaginationModel<T> {
   /// Creates an instance of BlowePaginationModel.
   ///
   /// - [items]: The list of items of type T.

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -75,7 +75,7 @@ class BlowePaginationListView<B extends BlowePaginationBloc<dynamic, P>, T, P>
             return _EmptyList<B, P>(
               paramsProvider: paramsProvider,
               padding: padding,
-              emptyWidget: emptyWidget,
+              emptyWidget: emptyWidget!,
             );
           }
           return _BlowePaginationListViewLoaded<B, T, P>(
@@ -192,9 +192,9 @@ class _EmptyList<B extends BlowePaginationBloc<dynamic, P>, P>
     extends StatelessWidget {
   const _EmptyList({
     required this.paramsProvider,
+    required this.emptyWidget,
     this.padding,
     super.key,
-    this.emptyWidget,
   });
 
   /// Optional padding for the list view.
@@ -204,7 +204,7 @@ class _EmptyList<B extends BlowePaginationBloc<dynamic, P>, P>
   final BloweFetchParamsProvider<P> paramsProvider;
 
   /// A widget to display when the list is empty.
-  final Widget? emptyWidget;
+  final Widget emptyWidget;
 
   @override
   Widget build(BuildContext context) {
@@ -212,10 +212,10 @@ class _EmptyList<B extends BlowePaginationBloc<dynamic, P>, P>
       onRefresh: () async {
         context.read<B>().add(BloweFetch(paramsProvider()));
       },
-      child: SingleChildScrollView(
+      child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
         padding: padding,
-        child: Center(child: emptyWidget),
+        children: [emptyWidget],
       ),
     );
   }

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -23,12 +23,14 @@ class BlowePaginationListView<B extends BlowePaginationBloc<dynamic, P>, T, P>
   /// - [itemBuilder]: The builder function to create list items.
   /// - [paramsProvider]: A function that provides parameters for the
   /// BloweFetch event.
+  /// - [emptyWidget]: A widget to display when the list is empty.
   /// - [padding]: Optional padding for the list view.
   const BlowePaginationListView({
     required this.itemBuilder,
     required this.paramsProvider,
-    super.key,
+    this.emptyWidget,
     this.padding,
+    super.key,
   });
 
   /// The builder function to create list items.
@@ -36,6 +38,9 @@ class BlowePaginationListView<B extends BlowePaginationBloc<dynamic, P>, T, P>
 
   /// A function that provides parameters for the BloweFetch event.
   final BloweFetchParamsProvider<P> paramsProvider;
+
+  /// A widget to display when the list is empty.
+  final Widget? emptyWidget;
 
   /// Optional padding for the list view.
   final EdgeInsetsGeometry? padding;
@@ -66,6 +71,13 @@ class BlowePaginationListView<B extends BlowePaginationBloc<dynamic, P>, T, P>
         }
 
         if (state is BloweCompleted<BlowePaginationModel<T>>) {
+          if (state.data.items.isEmpty && emptyWidget != null) {
+            return _EmptyList<B, P>(
+              paramsProvider: paramsProvider,
+              padding: padding,
+              emptyWidget: emptyWidget,
+            );
+          }
           return _BlowePaginationListViewLoaded<B, T, P>(
             data: state.data,
             isLoadingMore: state.isLoadingMore,
@@ -171,6 +183,39 @@ class __BlowePaginationListViewStateLoaded<
           final item = widget.data.items[index];
           return widget.itemBuilder(context, item);
         },
+      ),
+    );
+  }
+}
+
+class _EmptyList<B extends BlowePaginationBloc<dynamic, P>, P>
+    extends StatelessWidget {
+  const _EmptyList({
+    required this.paramsProvider,
+    this.padding,
+    super.key,
+    this.emptyWidget,
+  });
+
+  /// Optional padding for the list view.
+  final EdgeInsetsGeometry? padding;
+
+  /// A function that provides parameters for the BloweFetch event.
+  final BloweFetchParamsProvider<P> paramsProvider;
+
+  /// A widget to display when the list is empty.
+  final Widget? emptyWidget;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: () async {
+        context.read<B>().add(BloweFetch(paramsProvider()));
+      },
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: padding,
+        child: Center(child: emptyWidget),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blowe_bloc
 description: "An advanced Flutter package for state management and business logic components, extending flutter_bloc."
-version: 0.1.4
+version: 0.1.5
 repository: https://github.com/santiagogonzalezblowe/blowe_bloc
 issue_tracker: https://github.com/santiagogonzalezblowe/blowe_bloc/issues
 homepage: https://www.linkedin.com/in/santiagogonzalezblowe/


### PR DESCRIPTION
- Updated version to 0.1.5 in pubspec.yaml.
- Added the ability to pass a custom filter function to dynamically filter items in BlowePaginationListView.
- Updated the constructor to accept an optional filter parameter.
- Applied the filter to the items before displaying them.
- Ensured that the filtering works seamlessly with the existing onRefresh functionality.
- Made BlowePaginationModel non-abstract to allow instantiation.
- Added the ability to pass an `emptyWidget` to display when the list is empty.
- Wrapped the `emptyWidget` in a `RefreshIndicator` to allow onRefresh functionality even when the list is empty.
- Updated documentation and examples to reflect these changes.