### PR TITLE
Add group feature to BlowePaginationListView and update version to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.1.6
+
+- Added the ability to group items in BlowePaginationListView using a custom `groupBy` function.
+- Introduced `BloweGroupHeaderBuilder` to create custom group headers with access to the list of items in each group.
+- Ensured that grouped items are correctly displayed with headers and that the list remains scrollable.
+- Added an assert to ensure `groupBy` and `groupHeaderBuilder` are provided together for clearer error messages.
+- Updated the README.md to reflect the new version number 0.1.6.
+
 ## 0.1.5
 
 - Added the ability to pass a custom filter function to dynamically filter items in BlowePaginationListView.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use `blowe_bloc`, add it to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  blowe_bloc: ^0.1.3
+  blowe_bloc: ^0.1.6
 ```
 
 Then run \`flutter pub get\` to install the package.

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -54,7 +54,10 @@ class BlowePaginationListView<B extends BlowePaginationBloc<dynamic, P>, T, P,
     this.groupBy,
     this.groupHeaderBuilder,
     super.key,
-  });
+  }) : assert(
+          groupBy == null || groupHeaderBuilder != null,
+          'groupBy and groupHeaderBuilder must be provided together',
+        );
 
   /// The builder function to create list items.
   final BlowePaginationListViewItemBuilder<T> itemBuilder;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blowe_bloc
 description: "An advanced Flutter package for state management and business logic components, extending flutter_bloc."
-version: 0.1.5
+version: 0.1.6
 repository: https://github.com/santiagogonzalezblowe/blowe_bloc
 issue_tracker: https://github.com/santiagogonzalezblowe/blowe_bloc/issues
 homepage: https://www.linkedin.com/in/santiagogonzalezblowe/


### PR DESCRIPTION
- Added the ability to group items in BlowePaginationListView using a custom `groupBy` function.
- Introduced `BloweGroupHeaderBuilder` to create custom group headers with access to the list of items in each group.
- Ensured that grouped items are correctly displayed with headers and that the list remains scrollable.
- Added an assert to ensure `groupBy` and `groupHeaderBuilder` are provided together for clearer error messages.
- Updated the README.md to reflect the new version number 0.1.6.
- Updated the CHANGELOG.md to include the changes in version 0.1.6.