### PR TITLE
Add initialValue and readOnly properties to BloweTextFormField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.7
+
+- Added `initialValue` property to `BloweTextFormField` to set the initial value of the text field.
+- Added `readOnly` property to `BloweTextFormField` to indicate if the text field is read-only.
+- Updated the constructor documentation to include the new properties.
+- Ensured the new properties are used in the build method of the text form field.
+
 ## 0.1.6
 
 - Added the ability to group items in BlowePaginationListView using a custom `groupBy` function.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use `blowe_bloc`, add it to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  blowe_bloc: ^0.1.6
+  blowe_bloc: ^0.1.7
 ```
 
 Then run \`flutter pub get\` to install the package.

--- a/lib/src/widget/blowe_text_form_field.dart
+++ b/lib/src/widget/blowe_text_form_field.dart
@@ -32,6 +32,7 @@ typedef BloweTextFormFieldLabelTextBuilder = String Function(
 abstract class BloweTextFormField extends StatefulWidget {
   /// Creates an instance of BloweTextFormField.
   ///
+  /// - [labelText]: Builder function for the label text.
   /// - [obscureText]: Indicates if the text should be obscured
   /// (default is false).
   /// - [controller]: Optional TextEditingController.
@@ -41,7 +42,8 @@ abstract class BloweTextFormField extends StatefulWidget {
   /// - [keyboardType]: Optional keyboard type.
   /// - [textInputAction]: Optional text input action.
   /// - [suffixIcon]: Optional builder function for suffix icon.
-  /// - [labelText]: Builder function for the label text.
+  /// - [initialValue]: The initial value of the text field.
+  /// - [readOnly]: Indicates if the text field is read-only (default is false).
   const BloweTextFormField({
     required this.labelText,
     super.key,
@@ -53,6 +55,8 @@ abstract class BloweTextFormField extends StatefulWidget {
     this.keyboardType,
     this.textInputAction,
     this.suffixIcon,
+    this.initialValue,
+    this.readOnly = false,
   });
 
   /// Indicates if the text should be obscured.
@@ -81,6 +85,12 @@ abstract class BloweTextFormField extends StatefulWidget {
 
   /// Builder function for the label text.
   final BloweTextFormFieldLabelTextBuilder labelText;
+
+  /// The initial value of the text field.
+  final String? initialValue;
+
+  /// Indicates if the text field is read-only.
+  final bool readOnly;
 
   @override
   State<BloweTextFormField> createState() => _BloweTextFormFieldState();
@@ -113,6 +123,8 @@ class _BloweTextFormFieldState extends State<BloweTextFormField> {
       onEditingComplete: widget.onEditingComplete,
       keyboardType: widget.keyboardType,
       textInputAction: widget.textInputAction,
+      initialValue: widget.initialValue,
+      readOnly: widget.readOnly,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blowe_bloc
 description: "An advanced Flutter package for state management and business logic components, extending flutter_bloc."
-version: 0.1.6
+version: 0.1.7
 repository: https://github.com/santiagogonzalezblowe/blowe_bloc
 issue_tracker: https://github.com/santiagogonzalezblowe/blowe_bloc/issues
 homepage: https://www.linkedin.com/in/santiagogonzalezblowe/


### PR DESCRIPTION
- Added initialValue property to BloweTextFormField to set the initial value of the text field.
- Added readOnly property to BloweTextFormField to indicate if the text field is read-only.
- Updated the constructor documentation to include the new properties.
- Ensured the new properties are used in the build method of the text form field.
- Updated the version to 0.1.7 in pubspec.yaml.
- Updated the CHANGELOG.md to include the changes in version 0.1.7.
