### PR TITLE
Add onTap property to BloweTextFormField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.8
+
+- Added `onTap` property to `BloweTextFormField` to allow for custom tap handling.
+- Updated the constructor documentation to include the new `onTap` property.
+- Ensured the new property is used in the build method of the text form field.
+
 ## 0.1.7
 
 - Added `initialValue` property to `BloweTextFormField` to set the initial value of the text field.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use `blowe_bloc`, add it to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  blowe_bloc: ^0.1.7
+  blowe_bloc: ^0.1.8
 ```
 
 Then run \`flutter pub get\` to install the package.

--- a/lib/src/widget/blowe_text_form_field.dart
+++ b/lib/src/widget/blowe_text_form_field.dart
@@ -44,6 +44,7 @@ abstract class BloweTextFormField extends StatefulWidget {
   /// - [suffixIcon]: Optional builder function for suffix icon.
   /// - [initialValue]: The initial value of the text field.
   /// - [readOnly]: Indicates if the text field is read-only (default is false).
+  /// - [onTap]: Optional callback when the text field is tapped.
   const BloweTextFormField({
     required this.labelText,
     super.key,
@@ -57,6 +58,7 @@ abstract class BloweTextFormField extends StatefulWidget {
     this.suffixIcon,
     this.initialValue,
     this.readOnly = false,
+    this.onTap,
   });
 
   /// Indicates if the text should be obscured.
@@ -92,6 +94,9 @@ abstract class BloweTextFormField extends StatefulWidget {
   /// Indicates if the text field is read-only.
   final bool readOnly;
 
+  /// Optional callback when the text field is tapped.
+  final GestureTapCallback? onTap;
+
   @override
   State<BloweTextFormField> createState() => _BloweTextFormFieldState();
 }
@@ -125,6 +130,7 @@ class _BloweTextFormFieldState extends State<BloweTextFormField> {
       textInputAction: widget.textInputAction,
       initialValue: widget.initialValue,
       readOnly: widget.readOnly,
+      onTap: widget.onTap,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blowe_bloc
 description: "An advanced Flutter package for state management and business logic components, extending flutter_bloc."
-version: 0.1.7
+version: 0.1.8
 repository: https://github.com/santiagogonzalezblowe/blowe_bloc
 issue_tracker: https://github.com/santiagogonzalezblowe/blowe_bloc/issues
 homepage: https://www.linkedin.com/in/santiagogonzalezblowe/


### PR DESCRIPTION
- Added onTap property to BloweTextFormField to allow for custom tap handling.
- Updated the constructor documentation to include the new onTap property.
- Ensured the new property is used in the build method of the text form field.
- Updated the version to 0.1.8 in pubspec.yaml.
- Updated the CHANGELOG.md to include the changes in version 0.1.8.
