### PR TITLE
Add context to onTap and prefixIcon to BloweTextFormField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.9
+
+- Added `context` parameter to `onTap` callback in `BloweTextFormField` to provide access to the widget's context.
+- Added `prefixIcon` property to `BloweTextFormField` to allow for custom prefix icons.
+- Updated the constructor documentation to include the new properties.
+- Ensured the new properties are used in the build method of the text form field.
+
 ## 0.1.8
 
 - Added `onTap` property to `BloweTextFormField` to allow for custom tap handling.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use `blowe_bloc`, add it to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  blowe_bloc: ^0.1.8
+  blowe_bloc: ^0.1.9
 ```
 
 Then run \`flutter pub get\` to install the package.

--- a/lib/src/widget/blowe_text_form_field.dart
+++ b/lib/src/widget/blowe_text_form_field.dart
@@ -20,10 +20,24 @@ typedef BloweTextFormFieldSuffixIconBuilder = Widget Function(
   VoidCallback toggleObscureText,
 );
 
+/// Typedef for a prefix icon builder function used by BloweTextFormField.
+///
+/// - [context]: The BuildContext of the widget.
+typedef BloweTextFormFieldPrefixIconBuilder = Widget Function(
+  BuildContext context,
+);
+
 /// Typedef for a label text builder function used by BloweTextFormField.
 ///
 /// - [context]: The BuildContext of the widget.
 typedef BloweTextFormFieldLabelTextBuilder = String Function(
+  BuildContext context,
+);
+
+/// Typedef for an onTap callback used by BloweTextFormField.
+///
+/// - [context]: The BuildContext of the widget.
+typedef BloweTextFormFieldOnTap = void Function(
   BuildContext context,
 );
 
@@ -42,6 +56,7 @@ abstract class BloweTextFormField extends StatefulWidget {
   /// - [keyboardType]: Optional keyboard type.
   /// - [textInputAction]: Optional text input action.
   /// - [suffixIcon]: Optional builder function for suffix icon.
+  /// - [prefixIcon]: Optional builder function for prefix icon.
   /// - [initialValue]: The initial value of the text field.
   /// - [readOnly]: Indicates if the text field is read-only (default is false).
   /// - [onTap]: Optional callback when the text field is tapped.
@@ -56,6 +71,7 @@ abstract class BloweTextFormField extends StatefulWidget {
     this.keyboardType,
     this.textInputAction,
     this.suffixIcon,
+    this.prefixIcon,
     this.initialValue,
     this.readOnly = false,
     this.onTap,
@@ -85,6 +101,9 @@ abstract class BloweTextFormField extends StatefulWidget {
   /// Optional builder function for suffix icon.
   final BloweTextFormFieldSuffixIconBuilder? suffixIcon;
 
+  /// Optional builder function for prefix icon.
+  final BloweTextFormFieldPrefixIconBuilder? prefixIcon;
+
   /// Builder function for the label text.
   final BloweTextFormFieldLabelTextBuilder labelText;
 
@@ -95,7 +114,7 @@ abstract class BloweTextFormField extends StatefulWidget {
   final bool readOnly;
 
   /// Optional callback when the text field is tapped.
-  final GestureTapCallback? onTap;
+  final BloweTextFormFieldOnTap? onTap;
 
   @override
   State<BloweTextFormField> createState() => _BloweTextFormFieldState();
@@ -121,6 +140,7 @@ class _BloweTextFormFieldState extends State<BloweTextFormField> {
           _obscureText,
           toggleObscureText,
         ),
+        prefixIcon: widget.prefixIcon?.call(context),
       ),
       obscureText: _obscureText,
       validator: (value) => widget.validator?.call(context, value),
@@ -130,7 +150,7 @@ class _BloweTextFormFieldState extends State<BloweTextFormField> {
       textInputAction: widget.textInputAction,
       initialValue: widget.initialValue,
       readOnly: widget.readOnly,
-      onTap: widget.onTap,
+      onTap: () => widget.onTap?.call(context),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blowe_bloc
 description: "An advanced Flutter package for state management and business logic components, extending flutter_bloc."
-version: 0.1.8
+version: 0.1.9
 repository: https://github.com/santiagogonzalezblowe/blowe_bloc
 issue_tracker: https://github.com/santiagogonzalezblowe/blowe_bloc/issues
 homepage: https://www.linkedin.com/in/santiagogonzalezblowe/


### PR DESCRIPTION
- Added context parameter to onTap callback in BloweTextFormField to provide access to the widget's context.
- Added prefixIcon property to BloweTextFormField to allow for custom prefix icons.
- Updated the constructor documentation to include the new properties.
- Ensured the new properties are used in the build method of the text form field.
- Updated the version to 0.1.9 in pubspec.yaml.
- Updated the CHANGELOG.md to include the changes in version 0.1.9.