### PR TITLE
Release version 0.4.2: Add startWidget and endWidget support to BlowePaginationListView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.4.2
+
+### New Features
+
+- **BlowePaginationListView**:
+
+  - Added `startWidget` and `endWidget` support:
+    - `startWidget`: This optional widget is displayed at the beginning of the list (index 0).
+    - `endWidget`: This optional widget is displayed at the end of the list, before the `LinearProgressIndicator` when pagination is in progress.
+  - These widgets allow for greater flexibility in adding custom elements to the beginning or end of the paginated list, improving the ability to customize the user interface.
+
 ## 0.4.1
 
 ### Improvements

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -381,20 +381,17 @@ class __BlowePaginationListViewStateLoaded<
   }
 
   dynamic _getItemAtWithGroup(int index) {
-    if (widget.startWidget != null && index == 0) return widget.startWidget!;
-
-    final endWidgetIndex = _itemCount - (widget.isLoadingMore ? 2 : 1);
-    if (widget.endWidget != null && index == endWidgetIndex) {
-      return widget.endWidget!;
+    if (widget.startWidget != null && index == 0) {
+      return widget.startWidget!;
     }
 
-    var currentIndex = widget.startWidget != null ? index - 1 : index;
+    final currentIndex = widget.startWidget != null ? index - 1 : index;
 
     final groupedItems = _groupItems();
-    currentIndex = 0;
+    var totalIndex = 0;
 
     for (final group in groupedItems.entries) {
-      if (currentIndex == index) {
+      if (totalIndex == currentIndex) {
         return _GroupHeader(
           header: widget.groupHeaderBuilder!(
             context,
@@ -404,11 +401,18 @@ class __BlowePaginationListViewStateLoaded<
         );
       }
 
-      currentIndex++;
-      if (index < currentIndex + group.value.length) {
-        return group.value[index - currentIndex];
+      totalIndex++;
+
+      if (currentIndex < totalIndex + group.value.length) {
+        return group.value[currentIndex - totalIndex];
       }
-      currentIndex += group.value.length;
+
+      totalIndex += group.value.length;
+    }
+
+    final endWidgetIndex = _itemCount - (widget.isLoadingMore ? 2 : 1);
+    if (widget.endWidget != null && currentIndex == endWidgetIndex) {
+      return widget.endWidget!;
     }
 
     return null;

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -391,6 +391,7 @@ class __BlowePaginationListViewStateLoaded<
     var currentIndex = widget.startWidget != null ? index - 1 : index;
 
     final groupedItems = _groupItems();
+    currentIndex = 0;
 
     for (final group in groupedItems.entries) {
       if (currentIndex == index) {

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -335,10 +335,11 @@ class __BlowePaginationListViewStateLoaded<
             return const LinearProgressIndicator(minHeight: 2);
           }
 
-          final item = _getItemAt(index);
+          final item = widget.groupBy == null
+              ? _getItemAt(index)
+              : _getItemAtWithGroup(index);
 
           if (item is _GroupHeader) return item.header;
-
           if (item is Widget) return item;
 
           return widget.itemBuilder(context, item as T);
@@ -371,17 +372,25 @@ class __BlowePaginationListViewStateLoaded<
     }
 
     final endWidgetIndex = _itemCount - (widget.isLoadingMore ? 2 : 1);
+    if (widget.endWidget != null && index == endWidgetIndex) {
+      return widget.endWidget!;
+    }
 
+    final currentIndex = widget.startWidget != null ? index - 1 : index;
+    return widget.filteredData.items[currentIndex];
+  }
+
+  dynamic _getItemAtWithGroup(int index) {
+    if (widget.startWidget != null && index == 0) return widget.startWidget!;
+
+    final endWidgetIndex = _itemCount - (widget.isLoadingMore ? 2 : 1);
     if (widget.endWidget != null && index == endWidgetIndex) {
       return widget.endWidget!;
     }
 
     var currentIndex = widget.startWidget != null ? index - 1 : index;
 
-    if (widget.groupBy == null) return widget.filteredData.items[currentIndex];
-
     final groupedItems = _groupItems();
-    currentIndex = 0;
 
     for (final group in groupedItems.entries) {
       if (currentIndex == index) {

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -178,6 +178,8 @@ class BlowePaginationListView<
             itemBuilder: itemBuilder,
             padding: padding,
             paramsProvider: paramsProvider,
+            startWidget: startWidget,
+            endWidget: endWidget,
             groupBy: groupBy,
             groupHeaderBuilder: groupHeaderBuilder,
             onRefreshEnabled: onRefreshEnabled,

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -411,7 +411,7 @@ class __BlowePaginationListViewStateLoaded<
     }
 
     final endWidgetIndex = _itemCount - (widget.isLoadingMore ? 2 : 1);
-    if (widget.endWidget != null && currentIndex == endWidgetIndex) {
+    if (widget.endWidget != null && index == endWidgetIndex) {
       return widget.endWidget!;
     }
 

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -370,13 +370,13 @@ class __BlowePaginationListViewStateLoaded<
       return widget.startWidget!;
     }
 
-    var currentIndex = widget.startWidget != null ? index - 1 : index;
-
     final endWidgetIndex = _itemCount - (widget.isLoadingMore ? 2 : 1);
 
-    if (widget.endWidget != null && currentIndex == endWidgetIndex) {
+    if (widget.endWidget != null && index == endWidgetIndex) {
       return widget.endWidget!;
     }
+
+    var currentIndex = widget.startWidget != null ? index - 1 : index;
 
     if (widget.groupBy == null) return widget.filteredData.items[currentIndex];
 

--- a/lib/src/widget/blowe_pagination_list_view.dart
+++ b/lib/src/widget/blowe_pagination_list_view.dart
@@ -372,8 +372,9 @@ class __BlowePaginationListViewStateLoaded<
 
     var currentIndex = widget.startWidget != null ? index - 1 : index;
 
-    if (widget.endWidget != null &&
-        currentIndex == _itemCount - (widget.isLoadingMore ? 2 : 1)) {
+    final endWidgetIndex = _itemCount - (widget.isLoadingMore ? 2 : 1);
+
+    if (widget.endWidget != null && currentIndex == endWidgetIndex) {
       return widget.endWidget!;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blowe_bloc
 description: "An advanced Flutter package for state management and business logic components, extending flutter_bloc."
-version: 0.4.1
+version: 0.4.2
 repository: https://github.com/santiagogonzalezblowe/blowe_bloc
 issue_tracker: https://github.com/santiagogonzalezblowe/blowe_bloc/issues
 homepage: https://www.linkedin.com/in/santiagogonzalezblowe/


### PR DESCRIPTION
This PR introduces version 0.4.2 of the package with the following key updates:

	•	New Features:
	•	Added startWidget and endWidget to BlowePaginationListView:
	•	startWidget: An optional widget that can be displayed at the start of the list (index 0).
	•	endWidget: An optional widget that is placed before the LinearProgressIndicator at the end of the list when loading more data.
	•	Enhancements:
	•	Improved handling of item indexes, start, and end widgets when grouped data is used.
	•	Refined logic to ensure proper placement of endWidget even when pagination or loading is active.

This version enhances the flexibility and customizability of BlowePaginationListView, allowing users to include custom widgets at the start and end of the list while maintaining support for pagination and grouping.