### PR TITLE
Version 0.4.3: Autofill support, number style customization, and BloweMultiBlocSelector bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.4.3
+
+### Improvements
+
+- **BloweTextFormField**:
+
+  - Added support for the `autofillHints` property, allowing for better integration with autofill services. This makes it easier for users to autofill text fields such as emails, usernames, and passwords.
+
+- **BloweNumberFormListTile**:
+  - Introduced the `numberStyle` property, allowing users to customize the text style of the displayed number. This includes options to change the font, size, and color of the number text.
+  - When the widget is disabled, the number text now properly reflects the disabled state, ensuring that it matches the rest of the component visually.
+
+### Bug Fixes
+
+- **BloweMultiBlocSelector**:
+  - Fixed an issue where the initial state of the widget did not enable correctly. This was due to the lack of an initial value being emitted. The widget now emits the correct state upon initialization, ensuring that the widget's enabled state is accurate from the beginning.
+
 ## 0.4.2
 
 ### New Features

--- a/lib/src/widget/form/blowe_number_form_list_tile.dart
+++ b/lib/src/widget/form/blowe_number_form_list_tile.dart
@@ -174,7 +174,7 @@ class _BloweNumberFormListTileState extends State<BloweNumberFormListTile> {
         color: widget.enabled ? null : Theme.of(context).disabledColor,
       );
     } else {
-      return Theme.of(context).textTheme.labelLarge?.copyWith(
+      return Theme.of(context).textTheme.labelMedium?.copyWith(
             color: widget.enabled ? null : Theme.of(context).disabledColor,
           );
     }

--- a/lib/src/widget/form/blowe_number_form_list_tile.dart
+++ b/lib/src/widget/form/blowe_number_form_list_tile.dart
@@ -121,26 +121,12 @@ class _BloweNumberFormListTileState extends State<BloweNumberFormListTile> {
       builder: (state) {
         final hasError = state.hasError;
 
-        final shape = Theme.of(context).inputDecorationTheme.border?.copyWith(
-              borderSide: Theme.of(context)
-                  .inputDecorationTheme
-                  .border
-                  ?.borderSide
-                  .copyWith(
-                    color: widget.enabled
-                        ? hasError
-                            ? Theme.of(context).colorScheme.error
-                            : Theme.of(context).primaryColor
-                        : Theme.of(context).disabledColor,
-                  ),
-            );
-
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             ListTile(
               title: Text(widget.title(context)),
-              shape: shape,
+              shape: _getShape(hasError),
               enabled: widget.enabled,
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
@@ -149,11 +135,7 @@ class _BloweNumberFormListTileState extends State<BloweNumberFormListTile> {
                     onPressed: widget.enabled ? _decrementValue : null,
                     icon: const Icon(Icons.remove),
                   ),
-                  Text(
-                    '$_currentValue',
-                    style: widget.numberStyle ??
-                        Theme.of(context).textTheme.labelMedium,
-                  ),
+                  Text('$_currentValue', style: _numberStyle),
                   IconButton(
                     onPressed: widget.enabled ? _incrementValue : null,
                     icon: const Icon(Icons.add),
@@ -167,6 +149,35 @@ class _BloweNumberFormListTileState extends State<BloweNumberFormListTile> {
         );
       },
     );
+  }
+
+  InputBorder? _getShape(bool hasError) {
+    return Theme.of(context).inputDecorationTheme.border?.copyWith(
+          borderSide: Theme.of(context)
+              .inputDecorationTheme
+              .border
+              ?.borderSide
+              .copyWith(
+                color: widget.enabled
+                    ? hasError
+                        ? Theme.of(context).colorScheme.error
+                        : Theme.of(context).primaryColor
+                    : Theme.of(context).disabledColor,
+              ),
+        );
+  }
+
+  TextStyle? get _numberStyle {
+    final customText = widget.numberStyle;
+    if (customText != null) {
+      return customText.copyWith(
+        color: widget.enabled ? null : Theme.of(context).disabledColor,
+      );
+    } else {
+      return Theme.of(context).textTheme.labelLarge?.copyWith(
+            color: widget.enabled ? null : Theme.of(context).disabledColor,
+          );
+    }
   }
 }
 

--- a/lib/src/widget/form/blowe_number_form_list_tile.dart
+++ b/lib/src/widget/form/blowe_number_form_list_tile.dart
@@ -24,6 +24,7 @@ class BloweNumberFormListTile extends StatefulWidget {
   /// - [enabled]: Indicates if the field is enabled (default is true).
   /// - [minValue]: The minimum value allowed (default is 0).
   /// - [maxValue]: The maximum value allowed (optional).
+  /// - [numberStyle]: The style for the number text.
   const BloweNumberFormListTile({
     required this.controller,
     required this.title,
@@ -32,6 +33,7 @@ class BloweNumberFormListTile extends StatefulWidget {
     this.enabled = true,
     this.minValue = 0,
     this.maxValue,
+    this.numberStyle,
   });
 
   /// The controller for the number input field.
@@ -51,6 +53,9 @@ class BloweNumberFormListTile extends StatefulWidget {
 
   /// The maximum value allowed for the number input (optional).
   final int? maxValue;
+
+  /// The style for the number text.
+  final TextStyle? numberStyle;
 
   @override
   State<BloweNumberFormListTile> createState() =>
@@ -144,7 +149,11 @@ class _BloweNumberFormListTileState extends State<BloweNumberFormListTile> {
                     onPressed: widget.enabled ? _decrementValue : null,
                     icon: const Icon(Icons.remove),
                   ),
-                  Text('$_currentValue'),
+                  Text(
+                    '$_currentValue',
+                    style: widget.numberStyle ??
+                        Theme.of(context).textTheme.labelMedium,
+                  ),
                   IconButton(
                     onPressed: widget.enabled ? _incrementValue : null,
                     icon: const Icon(Icons.add),

--- a/lib/src/widget/form/blowe_text_form_field.dart
+++ b/lib/src/widget/form/blowe_text_form_field.dart
@@ -71,6 +71,7 @@ abstract class BloweTextFormField extends StatefulWidget {
   /// - [onTap]: Optional callback when the text field is tapped.
   /// - [inputFormatters]: Optional list of input formatters.
   /// - [maxLines]: The maximum number of lines to display (default is 1).
+  /// - [autofillHints]: Optional autofill hints for the text field.
   const BloweTextFormField({
     required this.labelText,
     this.hintText,
@@ -89,6 +90,7 @@ abstract class BloweTextFormField extends StatefulWidget {
     this.onTap,
     this.inputFormatters,
     this.maxLines = 1,
+    this.autofillHints,
   });
 
   /// Indicates if the text should be obscured.
@@ -140,6 +142,20 @@ abstract class BloweTextFormField extends StatefulWidget {
   /// If greater than 1, the field can handle multi-line input.
   final int? maxLines;
 
+  /// Optional autofill hints for the text field.
+  ///
+  /// This property provides hints to the autofill service about the type of
+  /// information expected in the text field. It can be used to improve the
+  /// accuracy and relevance of autofill suggestions.
+  ///
+  /// Example values include:
+  /// - [AutofillHints.email]: For email addresses.
+  /// - [AutofillHints.password]: For passwords.
+  /// - [AutofillHints.username]: For usernames.
+  ///
+  /// If null, no autofill hints will be provided.
+  final Iterable<String>? autofillHints;
+
   @override
   State<BloweTextFormField> createState() => _BloweTextFormFieldState();
 }
@@ -178,6 +194,7 @@ class _BloweTextFormFieldState extends State<BloweTextFormField> {
       onTap: () => widget.onTap?.call(context),
       inputFormatters: widget.inputFormatters,
       maxLines: widget.maxLines,
+      autofillHints: widget.autofillHints,
     );
   }
 

--- a/lib/src/widget/selector/blowe_multi_bloc_selector.dart
+++ b/lib/src/widget/selector/blowe_multi_bloc_selector.dart
@@ -49,6 +49,9 @@ class BloweMultiBlocSelectorState extends State<BloweMultiBlocSelector> {
   @override
   void initState() {
     super.initState();
+
+    _emitInitialValue();
+
     for (final bloc in widget.blocs) {
       bloc.stream.listen((state) {
         _streamController.add(
@@ -58,6 +61,13 @@ class BloweMultiBlocSelectorState extends State<BloweMultiBlocSelector> {
         );
       });
     }
+  }
+
+  void _emitInitialValue() {
+    final isEnabled = widget.blocs.every(
+      (bloc) => bloc.state is! BloweInProgress,
+    );
+    _streamController.add(isEnabled);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blowe_bloc
 description: "An advanced Flutter package for state management and business logic components, extending flutter_bloc."
-version: 0.4.2
+version: 0.4.3
 repository: https://github.com/santiagogonzalezblowe/blowe_bloc
 issue_tracker: https://github.com/santiagogonzalezblowe/blowe_bloc/issues
 homepage: https://www.linkedin.com/in/santiagogonzalezblowe/


### PR DESCRIPTION
This release includes several improvements and a critical bug fix:

### Improvements:
- **BloweTextFormField**: Added `autofillHints` to integrate autofill services, making it easier for users to fill in fields such as email, username, and password.
- **BloweNumberFormListTile**: Introduced a `numberStyle` property for customizing the number text. The number text now also reflects the disabled state, ensuring a consistent look when the widget is disabled.

### Bug Fix:
- **BloweMultiBlocSelector**: Resolved an issue where the initial state wasn't emitted, causing the widget to not enable correctly. The state is now properly initialized and emitted, ensuring the widget reflects the correct enabled state from the start.