### PR TITLE
Add support for FilledButton in BloweBlocButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.4.8
+
+### Improvements
+
+- **BloweBlocButton**:
+  - Added support for the new `FilledButton` widget.
+  - Now, you can use `FilledButton` in `BloweBlocButton` just like `ElevatedButton`, `TextButton`, and `OutlinedButton`.
+  - This addition aligns `BloweBlocButton` with the latest Material Design components and provides more styling options for your buttons.
+
 ## 0.4.7
 
 ### Improvements

--- a/lib/src/widget/blowe_bloc_button.dart
+++ b/lib/src/widget/blowe_bloc_button.dart
@@ -28,7 +28,7 @@ class BloweBlocButton<B extends BloweBloc<T, dynamic>,
   }
 
   /// Creates the button widget based on the type of ButtonStyleButton
-  /// (ElevatedButton, TextButton, OutlinedButton).
+  /// (ElevatedButton, TextButton, OutlinedButton, FilledButton).
   ///
   /// - [context]: The BuildContext of the widget.
   /// - [enabled]: Indicates if the button should be enabled.
@@ -46,6 +46,11 @@ class BloweBlocButton<B extends BloweBloc<T, dynamic>,
         );
       case const (OutlinedButton):
         return OutlinedButton(
+          onPressed: enabled ? onPressed : null,
+          child: Text(text),
+        );
+      case const (FilledButton):
+        return FilledButton(
           onPressed: enabled ? onPressed : null,
           child: Text(text),
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blowe_bloc
 description: "An advanced Flutter package for state management and business logic components, extending flutter_bloc."
-version: 0.4.7
+version: 0.4.8
 repository: https://github.com/santiagogonzalezblowe/blowe_bloc
 issue_tracker: https://github.com/santiagogonzalezblowe/blowe_bloc/issues
 homepage: https://www.linkedin.com/in/santiagogonzalezblowe/


### PR DESCRIPTION
This PR introduces the following changes:
	•	Adds support for the FilledButton widget in BloweBlocButton.
	•	Updates _createButton logic to include the FilledButton type.
	•	Enhances exception messages to clarify supported button types.
	•	Ensures BloweBlocButton aligns with the latest Material Design components for more flexibility and consistency.